### PR TITLE
Change project type to drupal

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,5 +1,5 @@
 name: lupus-decoupled
-type: drupal10
+type: drupal
 docroot: web
 php_version: "8.3"
 webserver_type: nginx-fpm


### PR DESCRIPTION
As it turns out, I merged #6 too quickly.

Here's another change: changing the project type from drupal10 to drupal.

A practical reason why: I was trying to run phpunit using a sqlite test database, but Drupal 11 (or something) was telling me that the minimum required version of sqlite [is 3.45.0](https://github.com/ddev/ddev/issues/6110). Apparently the 'drupal10' project image does not fit that requirement, but the 'drupal' image does.